### PR TITLE
enable to configure `publicEndpoint` settings

### DIFF
--- a/jvm/opencensus/README.md
+++ b/jvm/opencensus/README.md
@@ -2,7 +2,7 @@
 
 ## Sampling ratio setting (explicit setting required)
 
-You can controll sampling ratio of tracing. Higher sampling ratio covers most of incoming requests.
+You can control sampling ratio of tracing. Higher sampling ratio covers most of incoming requests.
 
 If your application is an non-root of a trace (get API/RPC request from traced system), no need to set sampling ratio. Because sampling ratio is controlled by root of trace. In other word, if your application may receive request from external (non-traced) application, you have to set sampling ratio.
 
@@ -17,6 +17,20 @@ Possible values are:
 - `never`
 
 Default value is `never` to prevent unexpected traces, so that you need to specify value explicitly to enable tracing.
+
+## Tracing context propagation setting
+
+You can control tracing context propagation between services.
+
+If your application is an non-root of a trace, you have to set endpoint public setting as false for viewing entire trace forest.
+
+To set tracing context propagation, set setting value into `M3_TRACER_OPENCENSUS_ENDPOINT_PUBLIC` environment variable or `m3.tracer.opencensus.endpoint.public` JVM system property.
+
+Possible values are:
+
+- `true` or `false`
+
+Default value is `true` to prevent unexpected tracing context propagation. You need to specify value to `false` if you enable to trace your backend service as part of entire trace forest.
 
 ## Side effect of `io.grpc.Context`
 

--- a/jvm/opencensus/src/main/kotlin/com/m3/tracing/tracer/opencensus/HttpRequestTracer.kt
+++ b/jvm/opencensus/src/main/kotlin/com/m3/tracing/tracer/opencensus/HttpRequestTracer.kt
@@ -11,7 +11,8 @@ import org.slf4j.LoggerFactory
 
 internal class HttpRequestTracer(
         private val tracer: Tracer,
-        private val textFormat: TextFormat
+        private val textFormat: TextFormat,
+        private val publicEndpoint: Boolean
 ) {
     @VisibleForTesting
     internal val getter = object: TextFormat.Getter<HttpRequestInfo>() {
@@ -22,7 +23,7 @@ internal class HttpRequestTracer(
     @VisibleForTesting
     internal val extractor = ExtractorImpl()
     @VisibleForTesting
-    internal val handler = HttpServerHandler(tracer, extractor, textFormat, getter, true)
+    internal val handler = HttpServerHandler(tracer, extractor, textFormat, getter, publicEndpoint)
 
     fun processRequest(request: HttpRequestInfo) = HttpRequestSpanImpl(handler, tracer, request).also {
         it.init()

--- a/jvm/opencensus/src/main/kotlin/com/m3/tracing/tracer/opencensus/M3OpenCensusTracer.kt
+++ b/jvm/opencensus/src/main/kotlin/com/m3/tracing/tracer/opencensus/M3OpenCensusTracer.kt
@@ -27,6 +27,7 @@ class M3OpenCensusTracer internal constructor(
 ) : M3Tracer {
     companion object {
         const val samplingConfigName = "m3.tracer.opencensus.sampling"
+        const val publicEndpointConfigName = "m3.tracer.opencensus.endpoint.public"
 
         private val logger = LoggerFactory.getLogger(M3OpenCensusTracer::class.java)
     }
@@ -39,7 +40,7 @@ class M3OpenCensusTracer internal constructor(
 
     private val sampler = createSampler()
     private val propagator = Tracing.getPropagationComponent()
-    private val httpRequestTracer = HttpRequestTracer(tracer, propagator.traceContextFormat)
+    private val httpRequestTracer = HttpRequestTracer(tracer, propagator.traceContextFormat, publicEndpoint())
 
     init {
         setupOpenCensus()
@@ -67,6 +68,8 @@ class M3OpenCensusTracer internal constructor(
     private fun createSampler() = SamplerFactory.createSampler(
             Config[samplingConfigName] ?: "never"
     )
+
+    private fun publicEndpoint() = (Config[publicEndpointConfigName] ?: "true").toBoolean()
 }
 
 internal class TraceContextImpl(

--- a/jvm/opencensus/src/test/kotlin/com/m3/tracing/tracer/opencensus/HttpRequestTracerTest.kt
+++ b/jvm/opencensus/src/test/kotlin/com/m3/tracing/tracer/opencensus/HttpRequestTracerTest.kt
@@ -26,7 +26,7 @@ class HttpRequestTracerTest {
         @Mock
         lateinit var httpRequest: HttpRequestInfo
 
-        private val httpRequestTracer by lazy { HttpRequestTracer(tracer, textFormat) }
+        private val httpRequestTracer by lazy { HttpRequestTracer(tracer, textFormat, true) }
 
         @Test
         fun `Should pass-through header`() {


### PR DESCRIPTION
Enable to configure tracing propagation context through `HttpServerHandler`'s `publicEndpoint` argument.