### PR TITLE
add `traceparent` header

### DIFF
--- a/jvm/core/src/main/kotlin/com/m3/tracing/M3Tracer.kt
+++ b/jvm/core/src/main/kotlin/com/m3/tracing/M3Tracer.kt
@@ -30,6 +30,13 @@ interface M3Tracer: AutoCloseable, TraceContext {
     fun processIncomingHttpRequest(request: HttpRequestInfo): HttpRequestSpan
 
     /**
+     * Start trace for outgoing HTTP request.
+     * Caller MUST close the [HttpRequestSpan] to prevent leak.
+     */
+    @CheckReturnValue
+    fun processOutgoingHttpRequest(request: HttpRequestInfo): HttpRequestSpan
+
+    /**
      * Returns context bound to current thread / call stack.
      *
      * When you get this object, it saves [TraceSpan] state of current thread / call stack.

--- a/jvm/core/src/main/kotlin/com/m3/tracing/http/HttpRequestInfo.kt
+++ b/jvm/core/src/main/kotlin/com/m3/tracing/http/HttpRequestInfo.kt
@@ -22,6 +22,11 @@ interface HttpRequestInfo {
      * @return If given header is not available, return null.
      */
     fun tryGetHeader(name: String): String?
+
+    /**
+     * Set value into header.
+     */
+    fun trySetHeader(name: String, value: String)
 }
 
 /**

--- a/jvm/opencensus/README.md
+++ b/jvm/opencensus/README.md
@@ -2,7 +2,7 @@
 
 ## Sampling ratio setting (explicit setting required)
 
-You can controll sampling ratio of tracing. Higher sampling ratio covers most of incoming requests.
+You can control sampling ratio of tracing. Higher sampling ratio covers most of incoming requests.
 
 If your application is an non-root of a trace (get API/RPC request from traced system), no need to set sampling ratio. Because sampling ratio is controlled by root of trace. In other word, if your application may receive request from external (non-traced) application, you have to set sampling ratio.
 
@@ -17,6 +17,20 @@ Possible values are:
 - `never`
 
 Default value is `never` to prevent unexpected traces, so that you need to specify value explicitly to enable tracing.
+
+## Tracing context propagation setting
+
+You can control tracing context propagation between services.
+
+If your application is an non-root of a trace, you have to set endpoint public setting as false for viewing entire trace forest.
+
+To set tracing context propagation, set setting value into `M3_TRACER_OPENCENSUS_ENDPOINT_PUBLIC` environment variable or `m3.tracer.opencensus.endpoint.public` JVM system property.
+
+Possible values are:
+
+- `true` or `false`
+
+Default value is `true` to prevent unexpected tracing context propagation. You need to specify value to `false` if you enable to trace your backend service as part of entire trace forest.
 
 ## Side effect of `io.grpc.Context`
 

--- a/jvm/opencensus/src/main/kotlin/com/m3/tracing/tracer/opencensus/HttpRequestTracer.kt
+++ b/jvm/opencensus/src/main/kotlin/com/m3/tracing/tracer/opencensus/HttpRequestTracer.kt
@@ -11,7 +11,8 @@ import org.slf4j.LoggerFactory
 
 internal class HttpRequestTracer(
         private val tracer: Tracer,
-        private val textFormat: TextFormat
+        private val textFormat: TextFormat,
+        private val publicEndpoint: Boolean
 ) {
     @VisibleForTesting
     internal val getter = object: TextFormat.Getter<HttpRequestInfo>() {
@@ -22,7 +23,7 @@ internal class HttpRequestTracer(
     @VisibleForTesting
     internal val extractor = ExtractorImpl()
     @VisibleForTesting
-    internal val handler = HttpServerHandler(tracer, extractor, textFormat, getter, true)
+    internal val handler = HttpServerHandler(tracer, extractor, textFormat, getter, publicEndpoint)
 
     fun processRequest(request: HttpRequestInfo) = HttpRequestSpanImpl(handler, tracer, request).also {
         it.init()

--- a/jvm/opencensus/src/main/kotlin/com/m3/tracing/tracer/opencensus/HttpRequestTracer.kt
+++ b/jvm/opencensus/src/main/kotlin/com/m3/tracing/tracer/opencensus/HttpRequestTracer.kt
@@ -4,6 +4,7 @@ import com.google.common.annotations.VisibleForTesting
 import com.m3.tracing.http.*
 import io.grpc.Context
 import io.opencensus.common.Scope
+import io.opencensus.contrib.http.HttpClientHandler
 import io.opencensus.contrib.http.HttpServerHandler
 import io.opencensus.trace.Tracer
 import io.opencensus.trace.propagation.TextFormat
@@ -21,11 +22,23 @@ internal class HttpRequestTracer(
         }
     }
     @VisibleForTesting
+    internal val setter = object: TextFormat.Setter<HttpRequestInfo>() {
+        override fun put(carrier: HttpRequestInfo, key: String, value: String) {
+            return carrier.trySetHeader(key, value)
+        }
+    }
+    @VisibleForTesting
     internal val extractor = ExtractorImpl()
     @VisibleForTesting
     internal val handler = HttpServerHandler(tracer, extractor, textFormat, getter, publicEndpoint)
+    @VisibleForTesting
+    internal val clientHandler = HttpClientHandler(tracer, extractor, textFormat, setter)
 
     fun processRequest(request: HttpRequestInfo) = HttpRequestSpanImpl(handler, tracer, request).also {
+        it.init()
+    }
+
+    fun processClientRequest(request: HttpRequestInfo) = HttpClientRequestSpanImpl(clientHandler, tracer, request).also {
         it.init()
     }
 }
@@ -85,3 +98,56 @@ internal class HttpRequestSpanImpl(
         }
     }
 }
+
+internal class HttpClientRequestSpanImpl(
+        private val handler: HttpClientHandler<HttpRequestInfo, HttpResponseInfo, HttpRequestInfo>,
+        override val tracer: Tracer,
+        private val request: HttpRequestInfo
+): TraceSpanImpl(null), HttpRequestSpan {
+    companion object {
+        private val logger = LoggerFactory.getLogger(HttpRequestTracer::class.java)
+    }
+
+    val context = handler.handleStart(tracer.currentSpan, request, request).also { context ->
+        request.tryGetMetadata(HttpRequestMetadataKey.ContentLength)?.let { length ->
+            if (length > 0) handler.handleMessageSent(context, length)
+        }
+    }
+
+    override val scopeParentContext: Context? get() = null
+    override val span = handler.getSpanFromContext(context)
+    override val scope: Scope? = tracer.withSpan(span)
+
+    @VisibleForTesting
+    internal var error: Throwable? = null
+    override fun setError(e: Throwable?) {
+        super<TraceSpanImpl>.setError(e)
+        this.error = e
+    }
+
+    @VisibleForTesting
+    internal var response: HttpResponseInfo? = null
+    override fun setResponse(response: HttpResponseInfo) {
+        this.response = response
+    }
+
+    override fun close() {
+        try {
+            captureInfo()
+            handler.handleEnd(context, request, response, error)
+        } catch (e: Throwable) {
+            logger.error("Failed to capture client response detail", e)
+        }
+
+        // Must close scope, span in ANY case to prevent memory leak.
+        // So that MUST call super.close().
+        super.close()
+    }
+
+    private fun captureInfo() {
+        response?.tryGetMetadata(HttpResponseMetadataKey.ContentLength)?.let { length ->
+            handler.handleMessageReceived(context, length)
+        }
+    }
+}
+

--- a/jvm/opencensus/src/main/kotlin/com/m3/tracing/tracer/opencensus/M3OpenCensusTracer.kt
+++ b/jvm/opencensus/src/main/kotlin/com/m3/tracing/tracer/opencensus/M3OpenCensusTracer.kt
@@ -27,6 +27,7 @@ class M3OpenCensusTracer internal constructor(
 ) : M3Tracer {
     companion object {
         const val samplingConfigName = "m3.tracer.opencensus.sampling"
+        const val publicEndpointConfigName = "m3.tracer.opencensus.endpoint.public"
 
         private val logger = LoggerFactory.getLogger(M3OpenCensusTracer::class.java)
     }
@@ -39,7 +40,7 @@ class M3OpenCensusTracer internal constructor(
 
     private val sampler = createSampler()
     private val propagator = Tracing.getPropagationComponent()
-    private val httpRequestTracer = HttpRequestTracer(tracer, propagator.traceContextFormat)
+    private val httpRequestTracer = HttpRequestTracer(tracer, propagator.traceContextFormat, publicEndpoint())
 
     init {
         setupOpenCensus()
@@ -67,6 +68,8 @@ class M3OpenCensusTracer internal constructor(
     private fun createSampler() = SamplerFactory.createSampler(
             Config[samplingConfigName] ?: "never"
     )
+
+    private fun publicEndpoint() = (Config[publicEndpointConfigName] ?: "true").toBoolean()
 }
 
 internal class TraceContextImpl(

--- a/jvm/opencensus/src/main/kotlin/com/m3/tracing/tracer/opencensus/M3OpenCensusTracer.kt
+++ b/jvm/opencensus/src/main/kotlin/com/m3/tracing/tracer/opencensus/M3OpenCensusTracer.kt
@@ -65,6 +65,8 @@ class M3OpenCensusTracer internal constructor(
 
     override fun processIncomingHttpRequest(request: HttpRequestInfo): HttpRequestSpan = httpRequestTracer.processRequest(request)
 
+    override fun processOutgoingHttpRequest(request: HttpRequestInfo): HttpRequestSpan = httpRequestTracer.processClientRequest(request)
+
     private fun createSampler() = SamplerFactory.createSampler(
             Config[samplingConfigName] ?: "never"
     )

--- a/jvm/opencensus/src/test/kotlin/com/m3/tracing/tracer/opencensus/HttpRequestTracerTest.kt
+++ b/jvm/opencensus/src/test/kotlin/com/m3/tracing/tracer/opencensus/HttpRequestTracerTest.kt
@@ -26,7 +26,7 @@ class HttpRequestTracerTest {
         @Mock
         lateinit var httpRequest: HttpRequestInfo
 
-        private val httpRequestTracer by lazy { HttpRequestTracer(tracer, textFormat) }
+        private val httpRequestTracer by lazy { HttpRequestTracer(tracer, textFormat, true) }
 
         @Test
         fun `Should pass-through header`() {

--- a/jvm/servlet/src/main/kotlin/com/m3/tracing/tracer/servlet/ServletHttpRequestInfo.kt
+++ b/jvm/servlet/src/main/kotlin/com/m3/tracing/tracer/servlet/ServletHttpRequestInfo.kt
@@ -10,6 +10,7 @@ open class ServletHttpRequestInfo(protected val req: HttpServletRequest): HttpRe
     // Thus this filter should not do anything breaks setCharacterEncoding() even after FilterCain.
 
     override fun tryGetHeader(name: String): String? = req.getHeader(name)
+    override fun trySetHeader(name: String, value: String) = Unit // Do nothing
 
     @Suppress("UNCHECKED_CAST", "IMPLICIT_ANY")
     override fun <T> tryGetMetadata(key: HttpRequestMetadataKey<T>): T? = when(key) {

--- a/jvm/spring-web/src/main/kotlin/com/m3/tracing/spring/http/client/SpringHttpRequestInfo.kt
+++ b/jvm/spring-web/src/main/kotlin/com/m3/tracing/spring/http/client/SpringHttpRequestInfo.kt
@@ -1,0 +1,21 @@
+package com.m3.tracing.spring.http.client
+
+import com.m3.tracing.http.HttpRequestInfo
+import com.m3.tracing.http.HttpRequestMetadataKey
+import org.springframework.http.HttpRequest
+
+open class SpringHttpRequestInfo(protected val req: HttpRequest): HttpRequestInfo {
+    override fun tryGetHeader(name: String): String? = req.headers.getFirst(name)
+    override fun trySetHeader(name: String, value: String) = req.headers.set(name, value)
+
+    @Suppress("UNCHECKED_CAST", "IMPLICIT_ANY")
+    override fun <T> tryGetMetadata(key: HttpRequestMetadataKey<T>): T? = when(key) {
+        HttpRequestMetadataKey.Method -> req.methodValue as T?
+        HttpRequestMetadataKey.Host -> req.headers.host?.hostName as T?
+        HttpRequestMetadataKey.ContentLength -> req.headers.contentLength.let { if (it <= 0) null else it } as T?
+        HttpRequestMetadataKey.Path -> req.uri.path as T?
+        HttpRequestMetadataKey.Url -> req.uri.toString() as T?
+
+        else -> null
+    }
+}


### PR DESCRIPTION
Current version's RestTemplate interceptor does not put `traceparent` header. So this PR provides interface to put `traceparent` for vairous http clients.

## Resources

- I learned how to use `HttpClientHandler` at this document.
  - https://github.com/census-instrumentation/opencensus-java/tree/ad508e11eae5bb23f3e2a4c01a87a5552c7a2d59/contrib/http_util
- `traceparent` header
  - https://www.w3.org/TR/trace-context/#traceparent-header