### PR TITLE
Prevent errors using old Servlet API

### DIFF
--- a/jvm/servlet/src/main/kotlin/com/m3/tracing/tracer/servlet/M3TracingFilter.kt
+++ b/jvm/servlet/src/main/kotlin/com/m3/tracing/tracer/servlet/M3TracingFilter.kt
@@ -33,12 +33,12 @@ open class M3TracingFilter: Filter {
     data class Config(
             val tracer: M3Tracer = M3TracerFactory.get(),
             val shutdownTracer: Boolean = true,
-            val isOldServletVersion: Boolean = false
+            val olderThanServlet3: Boolean = false
     ) {
         companion object {
             fun fromFilterConfig(filterConfig: FilterConfig) = Config(
                     shutdownTracer = (filterConfig.getInitParameter("shutdown_tracer") ?: "true").toBoolean(),
-                    isOldServletVersion = filterConfig.servletContext.majorVersion < 3
+                    olderThanServlet3 = filterConfig.servletContext.majorVersion < 3
             )
         }
     }
@@ -113,5 +113,5 @@ open class M3TracingFilter: Filter {
     }
 
     protected open fun wrapRequest(req: HttpServletRequest) = ServletHttpRequestInfo(req)
-    protected open fun wrapResponse(res: HttpServletResponse) = ServletHttpResponseInfo(res, this.config.isOldServletVersion)
+    protected open fun wrapResponse(res: HttpServletResponse) = ServletHttpResponseInfo(res, this.config.olderThanServlet3)
 }

--- a/jvm/servlet/src/main/kotlin/com/m3/tracing/tracer/servlet/M3TracingFilter.kt
+++ b/jvm/servlet/src/main/kotlin/com/m3/tracing/tracer/servlet/M3TracingFilter.kt
@@ -32,11 +32,13 @@ open class M3TracingFilter: Filter {
     @ThreadSafe
     data class Config(
             val tracer: M3Tracer = M3TracerFactory.get(),
-            val shutdownTracer: Boolean = true
+            val shutdownTracer: Boolean = true,
+            val isOldServletVersion: Boolean = false
     ) {
         companion object {
             fun fromFilterConfig(filterConfig: FilterConfig) = Config(
-                    shutdownTracer = (filterConfig.getInitParameter("shutdown_tracer") ?: "true").toBoolean()
+                    shutdownTracer = (filterConfig.getInitParameter("shutdown_tracer") ?: "true").toBoolean(),
+                    isOldServletVersion = filterConfig.servletContext.majorVersion < 3
             )
         }
     }
@@ -111,5 +113,5 @@ open class M3TracingFilter: Filter {
     }
 
     protected open fun wrapRequest(req: HttpServletRequest) = ServletHttpRequestInfo(req)
-    protected open fun wrapResponse(res: HttpServletResponse) = ServletHttpResponseInfo(res)
+    protected open fun wrapResponse(res: HttpServletResponse) = ServletHttpResponseInfo(res, this.config.isOldServletVersion)
 }

--- a/jvm/servlet/src/main/kotlin/com/m3/tracing/tracer/servlet/ServletHttpResponseInfo.kt
+++ b/jvm/servlet/src/main/kotlin/com/m3/tracing/tracer/servlet/ServletHttpResponseInfo.kt
@@ -4,11 +4,11 @@ import com.m3.tracing.http.HttpResponseInfo
 import com.m3.tracing.http.HttpResponseMetadataKey
 import javax.servlet.http.HttpServletResponse
 
-open class ServletHttpResponseInfo(protected val res: HttpServletResponse, private val isOldServletVersion: Boolean = false): HttpResponseInfo {
+open class ServletHttpResponseInfo(protected val res: HttpServletResponse, private val olderThanServlet3: Boolean = false): HttpResponseInfo {
 
     @Suppress("UNCHECKED_CAST", "IMPLICIT_ANY")
     override fun <T> tryGetMetadata(key: HttpResponseMetadataKey<T>): T? = when {
-        isOldServletVersion -> null
+        olderThanServlet3 -> null
         key == HttpResponseMetadataKey.StatusCode -> res.status as T?
         key == HttpResponseMetadataKey.ContentLength -> res.getHeader("Content-Length")?.toLongOrNull(10) as T?
         else -> null

--- a/jvm/servlet/src/main/kotlin/com/m3/tracing/tracer/servlet/ServletHttpResponseInfo.kt
+++ b/jvm/servlet/src/main/kotlin/com/m3/tracing/tracer/servlet/ServletHttpResponseInfo.kt
@@ -4,12 +4,13 @@ import com.m3.tracing.http.HttpResponseInfo
 import com.m3.tracing.http.HttpResponseMetadataKey
 import javax.servlet.http.HttpServletResponse
 
-open class ServletHttpResponseInfo(protected val res: HttpServletResponse): HttpResponseInfo {
+open class ServletHttpResponseInfo(protected val res: HttpServletResponse, private val isOldServletVersion: Boolean = false): HttpResponseInfo {
 
     @Suppress("UNCHECKED_CAST", "IMPLICIT_ANY")
-    override fun <T> tryGetMetadata(key: HttpResponseMetadataKey<T>): T? = when(key) {
-        HttpResponseMetadataKey.StatusCode -> res.status as T?
-        HttpResponseMetadataKey.ContentLength -> res.getHeader("Content-Length")?.toLongOrNull(10) as T?
+    override fun <T> tryGetMetadata(key: HttpResponseMetadataKey<T>): T? = when {
+        isOldServletVersion -> null
+        key == HttpResponseMetadataKey.StatusCode -> res.status as T?
+        key == HttpResponseMetadataKey.ContentLength -> res.getHeader("Content-Length")?.toLongOrNull(10) as T?
         else -> null
     }
 }

--- a/jvm/servlet/src/test/kotlin/com/m3/tracing/tracer/servlet/M3TracingFilterTest.kt
+++ b/jvm/servlet/src/test/kotlin/com/m3/tracing/tracer/servlet/M3TracingFilterTest.kt
@@ -13,6 +13,7 @@ import org.mockito.Mockito
 import org.mockito.junit.jupiter.MockitoExtension
 import javax.servlet.FilterChain
 import javax.servlet.FilterConfig
+import javax.servlet.ServletContext
 import javax.servlet.ServletRequest
 import javax.servlet.ServletResponse
 import javax.servlet.http.HttpServletRequest
@@ -25,11 +26,14 @@ class M3TracingFilterTest {
     class `Test filterConfig` {
         @Mock lateinit var tracer: M3Tracer
         @Mock lateinit var filterConfig: FilterConfig
+        @Mock lateinit var servletContext: ServletContext
         private val filter by lazy { M3TracingFilter() }
 
         @Test
         fun `test shutdown_tracer is false`() {
             Mockito.`when`(filterConfig.getInitParameter("shutdown_tracer")).thenReturn("false")
+            Mockito.`when`(filterConfig.servletContext).thenReturn(servletContext)
+            Mockito.`when`(servletContext.majorVersion).thenReturn(3)
 
             filter.init(filterConfig)
             Truth.assertThat(filter.config.shutdownTracer).isFalse()
@@ -38,6 +42,8 @@ class M3TracingFilterTest {
         @Test
         fun `test shutdown_tracer is true`() {
             Mockito.`when`(filterConfig.getInitParameter("shutdown_tracer")).thenReturn("true")
+            Mockito.`when`(filterConfig.servletContext).thenReturn(servletContext)
+            Mockito.`when`(servletContext.majorVersion).thenReturn(3)
 
             filter.init(filterConfig)
             Truth.assertThat(filter.config.shutdownTracer).isTrue()

--- a/jvm/servlet/src/test/kotlin/com/m3/tracing/tracer/servlet/ServletHttpResponseInfoTest.kt
+++ b/jvm/servlet/src/test/kotlin/com/m3/tracing/tracer/servlet/ServletHttpResponseInfoTest.kt
@@ -1,0 +1,34 @@
+package com.m3.tracing.tracer.servlet
+
+import com.google.common.truth.Truth
+import com.m3.tracing.http.HttpResponseMetadataKey
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.junit.jupiter.MockitoExtension
+import javax.servlet.http.HttpServletResponse
+
+@ExtendWith(MockitoExtension::class)
+class ServletHttpResponseInfoTest {
+
+    @Mock lateinit var res: HttpServletResponse
+
+    @Test
+    fun testMetadataValue() {
+        Mockito.`when`(res.status).thenReturn(200)
+        Mockito.`when`(res.getHeader("Content-Length")).thenReturn("1024")
+        val info = ServletHttpResponseInfo(res)
+        Truth.assertThat(info.tryGetMetadata(HttpResponseMetadataKey.StatusCode)).isInstanceOf(Integer::class.javaObjectType)
+        Truth.assertThat(info.tryGetMetadata(HttpResponseMetadataKey.StatusCode)).isEqualTo(200)
+        Truth.assertThat(info.tryGetMetadata(HttpResponseMetadataKey.ContentLength)).isInstanceOf(Long::class.javaObjectType)
+        Truth.assertThat(info.tryGetMetadata(HttpResponseMetadataKey.ContentLength)).isEqualTo(1024L)
+    }
+
+    @Test
+    fun testMetadataValueOldVersion() {
+        val info = ServletHttpResponseInfo(res, true)
+        Truth.assertThat(info.tryGetMetadata(HttpResponseMetadataKey.StatusCode)).isNull()
+        Truth.assertThat(info.tryGetMetadata(HttpResponseMetadataKey.ContentLength)).isNull()
+    }
+}


### PR DESCRIPTION
As Servlet API less than ver. 3.0 doesn't have `getHeader()` nor `getStatus()` method, `tryGetMetadata()` of `ServletHttpResponseInfo` raises error.
So, we change `ServletHttpResponseInfo` not to call them when the Servlet API is old.