### PR TITLE
versioning kotlin.plugin.spring

### DIFF
--- a/jvm/build.gradle.kts
+++ b/jvm/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 
 allprojects {
     group = "com.m3.tracing"
-    version = "2.0.1"
+    version = "2.0.2-SNAPSHOT"
 
     repositories {
         jcenter()

--- a/jvm/spring-boot/build.gradle.kts
+++ b/jvm/spring-boot/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     kotlin("jvm")
 
     // For spring-boot
-    id("org.jetbrains.kotlin.plugin.spring") version "1.3.21"
+    id("org.jetbrains.kotlin.plugin.spring") version "1.7.22"
 }
 
 dependencies {


### PR DESCRIPTION
fixing `org.jetbrains.kotlin.plugin.spring` version to 1.7.x according to Kotlin version.